### PR TITLE
Fix extreme lag while typing in 2500-line Elixir files.

### DIFF
--- a/Contents/Language Modules/Elixir.plist
+++ b/Contents/Language Modules/Elixir.plist
@@ -299,12 +299,12 @@
 		<key>Function Pattern</key>
 		<string><![CDATA[
 		(?x:
-			(?P<indent>^\s*)
+			(?P<indent>^[ \t]*)
 			(?P<function>
 				def(macro)?p?\s+
 				(?P<function_name>[a-zA-Z0-9_:?@!%]+)
 				(
-					(?s:.+)\n(?P=indent)end\b |
+				    (.*\n)(^(?!(?P=indent)end\b).*$\n?)*(?P=indent)end\b | (?# First consume the remainder of the first line--that contains the function name--if there is any remainder. Then consume all lines that don't begin with the indented "end" we're looking for. Finally, consume the "end" token.)
 					(.+\sdo:.+)
 				)
 			)


### PR DESCRIPTION
Before: 1 char per second on an M1. After: no measurable lag.

Replace a non-greedy regex (which requires a lot of backtracking) with a greedy one.

Also tweak the `<indent>` subpattern to exclude newlines: this was causing some functions to be missed by the scanner, because the scanner would extend an earlier function until it happened to encounter a properly indented "end" with exactly the same pattern of newlines as it found above the function.